### PR TITLE
Removing-Some-Hardcoded-Variables

### DIFF
--- a/boundary-demo-eks/data.tf
+++ b/boundary-demo-eks/data.tf
@@ -51,8 +51,8 @@ data "aws_key_pair" "aws_key_name" {
 }
 
 data "tfe_outputs" "boundary_demo_init" {
-  organization = "swhashi"
-  workspace    = "boundary-demo-init"
+  organization = var.tfc_org
+  workspace    = var.init_workspace_name
 }
 
 data "aws_arn" "peer_vpc" {

--- a/boundary-demo-eks/okta.tf
+++ b/boundary-demo-eks/okta.tf
@@ -23,21 +23,34 @@ resource "okta_app_oauth" "okta_app" {
   }
 }
 
-# Assign the pie, dev and IT users groups to the Okta App
-# Need to replace the group_id with your own group_ids from Okta.  Will look at getting this from a data source in the future
+# Create then assign the pie, dev and IT users groups to the Okta App
+resource "okta_group" "pie_users" {
+  name        = "pie_users"
+  description = "Platform Infrastructure Engineering Group"
+}
+
 resource "okta_app_group_assignment" "pie_users" {
   app_id   = okta_app_oauth.okta_app.id
-  group_id = "00g8szskt98pefZWy5d7"
+  group_id = okta_group.pie_users.id
+}
+resource "okta_group" "dev_users" {
+  name        = "dev_users"
+  description = "Developer User Group"
 }
 
 resource "okta_app_group_assignment" "dev_users" {
   app_id   = okta_app_oauth.okta_app.id
-  group_id = "00g82ne7guXwzhoJK5d7"
+  group_id = okta_group.dev_users.id
+}
+
+resource "okta_group" "it_users" {
+  name        = "it_users"
+  description = "IT User Group"
 }
 
 resource "okta_app_group_assignment" "it_users" {
   app_id   = okta_app_oauth.okta_app.id
-  group_id = "00g8vpasgeWmVvh3O5d7"
+  group_id = okta_group.it_users.id
 }
 
 # Create the OIDC auth method in boundary linked to the Okta Oauth App

--- a/boundary-demo-eks/variables.tf
+++ b/boundary-demo-eks/variables.tf
@@ -4,6 +4,16 @@ variable "region" {
   default     = "us-west-2"
 }
 
+variable "tfc_org" {
+  description = "Terraform Cloud Organization name."
+  type = string
+}
+
+variable "init_workspace_name" {
+  description = "Terraform Cloud Workspace name used for the initial resources i.e- boundary-demo-init."
+  type = string
+}
+
 variable "boundary_password" {
   description = "The Boundary admin user that will be set in the provider"
   type        = string

--- a/boundary-demo-init/providers.tf
+++ b/boundary-demo-init/providers.tf
@@ -7,11 +7,14 @@ terraform {
     }
   }
   cloud {
-    organization = "swhashi"
+    organization = var.tfc_org
     workspaces {
-      name = "boundary-demo-init"
+      name = var.workspace_name
     }
   }
 }
 
-provider "hcp" {}
+provider "hcp" {
+  client_id     = var.hcp_client_id
+  client_secret = var.hcp_client_secret
+}

--- a/boundary-demo-init/variables.tf
+++ b/boundary-demo-init/variables.tf
@@ -1,7 +1,30 @@
+variable "hcp_client_id" {
+  description = "HCP Client ID to authenticate to HCP."
+  type = string
+}
+
+variable "hcp_client_secret" {
+  description = "HCP Client Secret to authenticate to HCP."
+  type = string
+  sensitive   = true
+}
+
+variable "tfc_org" {
+  description = "Terraform Cloud Organization name."
+  type = string
+}
+
+variable "workspace_name" {
+  description = "Terraform Cloud Workspace name."
+  type = string
+}
+
 variable "boundary_user" {
+  description = "Username for the Boundary User to be created."
   type = string
 }
 
 variable "boundary_password" {
+  description = "Password for the Boundary User to be created."
   type = string
 }

--- a/readme.md
+++ b/readme.md
@@ -36,21 +36,25 @@ This repo consists of two modules:
 | --------- | -------- | -------- |
 | boundary_user | terraform | The user name you would like to use for the default admin user created in the HCP Boundary Cluster |
 | boundary_password | terraform | The password you would like to use for the default admin user created in the HCP Boundary Cluster |
-| HCP_CLIENT_ID | environment | The Client ID used to authenticate to HCP |
-| HCP_CLIENT_SECRET | environment | The Secret Key used to authenticate to HCP |
+| hcp_client_id | terraform | The Client ID used to authenticate to HCP |
+| hcp_client_secret | terraform | The Secret Key used to authenticate to HCP |
+| tfc_org | terraform | Terraform Cloud Organization name |
+| workspace_name | terraform | Terraform Cloud Workspace name (i.e. boundary-demo-init)|
 
 #### boundary-demo-eks
 | Variable | Type | Purpose |
 | --------- | -------- | -------- |
-| region | terraform | The AWS region to deploy worker and targets into |
+| region | terraform | The AWS region to deploy worker and targets into (us-west-2 used in the demo-init)|
+| tfc_org | terraform | Terraform Cloud Organization name |
+| init_workspace_name | terraform | Terraform Cloud Workspace name used for the initial resources (i.e. boundary-demo-init)|
 | boundary_user | terraform | The Boundary admin user that will be set in the provider | 
 | boundary_password | terraform | The Boundary admin user password that will be set in the provider |
 | db_user | terraform | The username to set on the Postgres database Boundary target |
 | db_password | terraform | The password to set on the Postgres database Boundary target |
 | okta_baseurl | terraform | The base url for the Okta organization used for OIDC integration.  Probably okta.com |
 | okta_org_name | terraform | The organization name for the Okta organization use for OIDC integration i.e. dev-32201783 |
-| HCP_CLIENT_ID | environment | The Client ID used to authenticate the HCP provider |
-| HCP_CLIENT_SECRET | environment | The Secret Key used to authenticate the HCP provider |
+| hcp_client_id | terraform | The Client ID used to authenticate to HCP |
+| hcp_client_secret | terraform | The Secret Key used to authenticate to HCP |
 | OKTA_API_TOKEN | environment | The token used to authenticate the Okta provider |
 | TFE_TOKEN | environment | The token used to authenticate the Terraform provider to use the tfe_outputs data source |
 | AWS_ACCESS_KEY_ID | environment | The AWS Access Key used to authenticate the AWS provider |


### PR DESCRIPTION
This PR could break aspects of TF runs, but would overall make it easier for future SEs to leverage this repo. Certain vars (i.e. TF org & workspace name, would need to be added in the workspaces) some need to be changed to tf vars rather than env. Also note the okta group is now created via TF and referenced via the created resource, which might be problematic if it is used other places. 

Removed hard coded vars like- 
	• Terraform org
	• Workspaces
	• Okta group IDs

Added Variables for 
	• Terraform org
	• Workspaces

Switched hcp_client_id & hcp_client_secret to terraform variables rather than env. Now that I think about it, there's really no good reason for this one. 

Added to the TF Code- 
	• Okta Group Creation 
Okta references to newly created groups 